### PR TITLE
Added support for changing brightness using the keyboard buttons

### DIFF
--- a/20-intel.conf
+++ b/20-intel.conf
@@ -1,0 +1,6 @@
+Section "Device"
+        Identifier  "card0"
+        Driver      "intel"
+        Option      "Backlight"  "intel_backlight"
+        BusID       "PCI:0:2:0"
+EndSection

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,10 @@
+# Install support for brightness keybord buttons
+xorg_dir="/etc/X11/xorg.conf.d/"
+if [[ ! -e $xorg_dir ]]; then
+    sudo mkdir $xorg_dir
+fi
+sudo cp 20-intel.conf $xorg_dir
+
 # Install switchable graphics init script
 echo "copying custom switchable graphics init file (turns off radeon card)"
 sudo cp switchable-graphics.conf /etc/init/


### PR DESCRIPTION
Changing the brightness using the keyboard (F2 - F3) brightness buttons didn't work for me in Ubuntu 14.04, this should fix that.